### PR TITLE
Remove dependencies from meta/main.yml.

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -20,5 +20,4 @@ galaxy_info:
 
   galaxy_tags: []
 
-dependencies:
-  - wandansible.prometheus_exporter
+dependencies: []


### PR DESCRIPTION
All role dependencies listed in meta/main.yml are implicitly executed by ansible before the role is executed.

Remove dependencies from meta/main.yml as we want to control the order dependencies are executed in.